### PR TITLE
Add accept-encoding header to the request

### DIFF
--- a/lib/infusionsoft/connection.rb
+++ b/lib/infusionsoft/connection.rb
@@ -12,7 +12,7 @@ module Infusionsoft
         'port' => 443,
         'use_ssl' => true
       })
-      client.http_header_extra = {'User-Agent' => user_agent}
+      client.http_header_extra = {'User-Agent' => user_agent, "accept-encoding" => "identity"}
       begin
         api_logger.info "CALL: #{service_call} api_url: #{api_url} api_key:#{api_key} at:#{Time.now} args:#{args.inspect}"
         result = client.call("#{service_call}", api_key, *args)


### PR DESCRIPTION
Sidekiq is throwing out an error on production: `Wrong size. Was 1070, should be 309`

According to multiple comments (including some from here http://stackoverflow.com/questions/15640764/ruby-2-0p0-and-xmlrpcclient) adding the header will make our issue go away.
